### PR TITLE
[FEAT#1] ubuntu용 Ansible postgresql role 입니다. 

### DIFF
--- a/ansible/roles/postgresql_setup_ubuntu/defaults/main.yml
+++ b/ansible/roles/postgresql_setup_ubuntu/defaults/main.yml
@@ -1,0 +1,7 @@
+db_name: "{{ lookup('env', 'DB_NAME') }}"
+db_user: "{{ lookup('env', 'DB_USER') }}"
+db_pass: "{{ lookup('env', 'DB_PASS') }}"
+postgres_password: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
+pg_version: 16
+pg_conf_path: "/etc/postgresql/{{ pg_version }}/main/postgresql.conf"
+pg_hba_path: "/etc/postgresql/{{ pg_version }}/main/pg_hba.conf"

--- a/ansible/roles/postgresql_setup_ubuntu/meta/main.yml
+++ b/ansible/roles/postgresql_setup_ubuntu/meta/main.yml
@@ -1,0 +1,7 @@
+galaxy_info:
+  author: yhs
+  description: PostgreSQL setup (Ubuntu)
+  license: MIT
+  min_ansible_version: 2.9
+
+dependencies: []

--- a/ansible/roles/postgresql_setup_ubuntu/postgresql_setup_ubuntu.yml
+++ b/ansible/roles/postgresql_setup_ubuntu/postgresql_setup_ubuntu.yml
@@ -1,0 +1,6 @@
+- name: PostgreSQL Role 실행
+  hosts: ansi2
+  become: yes
+
+  roles:
+    - postgresql_setup

--- a/ansible/roles/postgresql_setup_ubuntu/postgresql_setup_ubuntu.yml
+++ b/ansible/roles/postgresql_setup_ubuntu/postgresql_setup_ubuntu.yml
@@ -3,4 +3,4 @@
   become: yes
 
   roles:
-    - postgresql_setup
+    - postgresql_setup_ubuntu

--- a/ansible/roles/postgresql_setup_ubuntu/tasks/main.yml
+++ b/ansible/roles/postgresql_setup_ubuntu/tasks/main.yml
@@ -1,0 +1,65 @@
+- name: 패키지 설치
+  apt:
+    name:
+      - postgresql
+      - postgresql-contrib
+      - python3-psycopg2
+      - acl
+    state: present
+    update_cache: yes
+
+- name: 1. 서비스 시작 및 활성화
+  systemd:
+    name: postgresql
+    state: started
+    enabled: yes
+
+- name: 2. listen_addresses 설정
+  lineinfile:
+    path: "{{ pg_conf_path }}"
+    regexp: "^#?listen_addresses"
+    line: "listen_addresses = '*'"
+
+- name: 3. password_encryption 설정
+  lineinfile:
+    path: "{{ pg_conf_path }}"
+    regexp: "^#?password_encryption"
+    line: "password_encryption = md5"
+
+- name: 4. localhost md5 접속 허용
+  replace:
+    path: "{{ pg_hba_path }}"
+    regexp: '^(host\s+all\s+all\s+(127\.0\.0\.1\/32|::1\/128)\s+)(ident|scram-sha-256|trust|peer)$'
+    replace: '\1md5'
+
+- name: 5. 외부 접속 허용
+  lineinfile:
+    path: "{{ pg_hba_path }}"
+    line: "host     all     all     0.0.0.0/0     md5"
+    insertafter: EOF
+
+- name: 6. postgres 비밀번호 설정
+  postgresql_user:
+    name: postgres
+    password: "{{ postgres_password }}"
+  become: yes
+  become_user: postgres
+
+- name: 7. 사용자 생성
+  postgresql_user:
+    name: "{{ db_user }}"
+    password: "{{ db_pass }}"
+  become: yes
+  become_user: postgres
+
+- name: 8. DB 생성
+  postgresql_db:
+    name: "{{ db_name }}"
+    owner: "{{ db_user }}"
+  become: yes
+  become_user: postgres
+
+- name: 9. 서비스 재시작 
+  systemd:
+    name: postgresql
+    state: restarted

--- a/ansible/roles/postgresql_setup_ubuntu/vars/main.yml
+++ b/ansible/roles/postgresql_setup_ubuntu/vars/main.yml
@@ -1,0 +1,2 @@
+pg_conf_path: "/etc/postgresql/{{ pg_version }}/main/postgresql.conf"
+pg_hba_path: "/etc/postgresql/{{ pg_version }}/main/pg_hba.conf"

--- a/ansible/roles/postgresql_setup_ubuntu/vars/main.yml
+++ b/ansible/roles/postgresql_setup_ubuntu/vars/main.yml
@@ -1,2 +1,0 @@
-pg_conf_path: "/etc/postgresql/{{ pg_version }}/main/postgresql.conf"
-pg_hba_path: "/etc/postgresql/{{ pg_version }}/main/pg_hba.conf"


### PR DESCRIPTION
## Summary

- 배경: linux중 debian 계열인 ubuntu도 서버로 자주 사용 됨
- 목적: 수동으로 설치부터 사용자 계정을 만들기 보다는 경제적 이득을 위하여 Ansible role북을 사용

## Changes

rocky에서 DB init 했던 부분 삭제.
.env 파일 만들어서 환경변수 선언하여 하드코딩 방지 

## Review Points

- 중점적으로 봐야 할 부분:
defaults의 main.yml의 lookup함수 설정, tasks 의 main.yml 작업 순서 
