### PR TITLE
[FEAT#5] 모니터링 도구 설치 및 설정 - Prometheus & Grafana

### DIFF
--- a/ansible/monitor_remove.yml
+++ b/ansible/monitor_remove.yml
@@ -1,0 +1,8 @@
+---
+- name: "모니터링 도구 제거"
+  hosts: localhost
+  connection: local
+  become: yes
+
+  roles:
+    - monitor_remove

--- a/ansible/monitor_setup.yml
+++ b/ansible/monitor_setup.yml
@@ -1,0 +1,8 @@
+---
+- name: "모니터링 도구 설치 및 설정"
+  hosts: localhost
+  connection: local
+  become: yes
+
+  roles:
+    - monitor_setup

--- a/ansible/node_exporter_remove.yml
+++ b/ansible/node_exporter_remove.yml
@@ -1,0 +1,8 @@
+# ~/ansible/node_exporter_remove.yml
+---
+- name: "Node Exporter 제거 (전 호스트)"
+  hosts: all
+  become: yes
+
+  roles:
+    - node_exporter_remove

--- a/ansible/node_exporter_setup.yml
+++ b/ansible/node_exporter_setup.yml
@@ -1,0 +1,8 @@
+# ~/ansible/node_exporter_setup.yml
+---
+- name: "Node Exporter 설치 (전 호스트)"
+  hosts: all
+  become: yes
+
+  roles:
+    - node_exporter_setup

--- a/ansible/roles/monitor_remove/defaults/main.yml
+++ b/ansible/roles/monitor_remove/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Monitoring Remove Role Defaults
+# 이 role 은 모니터링 서버(Local) 의 prometheus + grafana 를 제거합니다.
+# node_exporter 는 별도의 node_exporter_remove role 로 분리되어 있습니다.
+
+monitoring_components:
+  - prometheus
+  - grafana
+
+# Prometheus 설치 위치 (collection 기반 설치 기준)
+prometheus_paths:
+  - /usr/local/bin/prometheus
+  - /usr/local/bin/promtool
+  - /etc/prometheus
+  - /var/lib/prometheus
+  - /etc/systemd/system/prometheus.service
+
+# Grafana 패키지 정리 시 제거할 저장소 정의
+grafana_repo_path_redhat: /etc/yum.repos.d/grafana.repo
+grafana_apt_repo: "deb https://packages.grafana.com/oss/deb stable main"
+grafana_apt_repo_filename: grafana
+grafana_apt_key_url: https://packages.grafana.com/gpg.key

--- a/ansible/roles/monitor_remove/meta/main.yml
+++ b/ansible/roles/monitor_remove/meta/main.yml
@@ -1,0 +1,9 @@
+---
+galaxy_info:
+  author: AZAS Team
+  description: Remove monitoring stack (node_exporter, prometheus, grafana)
+  company: AZAS
+  license: license (BSD, MIT)
+  min_ansible_version: 2.9
+
+dependencies: []

--- a/ansible/roles/monitor_remove/tasks/grafana.yml
+++ b/ansible/roles/monitor_remove/tasks/grafana.yml
@@ -1,6 +1,6 @@
 ---
 - name: "1. Grafana 서비스 중지 및 비활성화"
-  ansible.builtin.systemd:
+  systemd:
     name: grafana-server
     state: stopped
     enabled: no
@@ -8,34 +8,34 @@
 
 # --- RedHat 계열 ---
 - name: "2. Grafana 패키지 제거 (RedHat)"
-  ansible.builtin.dnf:
+  dnf:
     name: grafana
     state: absent
   when: ansible_os_family == "RedHat"
 
 - name: "3. Grafana YUM 저장소 제거 (RedHat)"
-  ansible.builtin.file:
+  file:
     path: "{{ grafana_repo_path_redhat }}"
     state: absent
   when: ansible_os_family == "RedHat"
 
 # --- Debian 계열 ---
 - name: "4. Grafana 패키지 제거 (Debian)"
-  ansible.builtin.apt:
+  apt:
     name: grafana
     state: absent
     purge: yes
   when: ansible_os_family == "Debian"
 
 - name: "5. Grafana APT 저장소 제거 (Debian)"
-  ansible.builtin.apt_repository:
+  apt_repository:
     repo: "{{ grafana_apt_repo }}"
     state: absent
     filename: "{{ grafana_apt_repo_filename }}"
   when: ansible_os_family == "Debian"
 
 - name: "6. Grafana GPG 키 제거 (Debian)"
-  ansible.builtin.apt_key:
+  apt_key:
     url: "{{ grafana_apt_key_url }}"
     state: absent
   when: ansible_os_family == "Debian"

--- a/ansible/roles/monitor_remove/tasks/grafana.yml
+++ b/ansible/roles/monitor_remove/tasks/grafana.yml
@@ -1,0 +1,41 @@
+---
+- name: "1. Grafana 서비스 중지 및 비활성화"
+  ansible.builtin.systemd:
+    name: grafana-server
+    state: stopped
+    enabled: no
+  failed_when: false
+
+# --- RedHat 계열 ---
+- name: "2. Grafana 패키지 제거 (RedHat)"
+  ansible.builtin.dnf:
+    name: grafana
+    state: absent
+  when: ansible_os_family == "RedHat"
+
+- name: "3. Grafana YUM 저장소 제거 (RedHat)"
+  ansible.builtin.file:
+    path: "{{ grafana_repo_path_redhat }}"
+    state: absent
+  when: ansible_os_family == "RedHat"
+
+# --- Debian 계열 ---
+- name: "4. Grafana 패키지 제거 (Debian)"
+  ansible.builtin.apt:
+    name: grafana
+    state: absent
+    purge: yes
+  when: ansible_os_family == "Debian"
+
+- name: "5. Grafana APT 저장소 제거 (Debian)"
+  ansible.builtin.apt_repository:
+    repo: "{{ grafana_apt_repo }}"
+    state: absent
+    filename: "{{ grafana_apt_repo_filename }}"
+  when: ansible_os_family == "Debian"
+
+- name: "6. Grafana GPG 키 제거 (Debian)"
+  ansible.builtin.apt_key:
+    url: "{{ grafana_apt_key_url }}"
+    state: absent
+  when: ansible_os_family == "Debian"

--- a/ansible/roles/monitor_remove/tasks/main.yml
+++ b/ansible/roles/monitor_remove/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# Monitoring Remove Role - Main task file
+
+- name: "Monitoring stack removal"
+  block:
+    - name: "OS family fact 수집"
+      ansible.builtin.setup:
+        gather_subset: min
+      when: ansible_facts.os_family is not defined
+
+    - name: "Prometheus 제거"
+      include_tasks: prometheus.yml
+      when: "'prometheus' in monitoring_components"
+
+    - name: "Grafana 제거"
+      include_tasks: grafana.yml
+      when: "'grafana' in monitoring_components"

--- a/ansible/roles/monitor_remove/tasks/prometheus.yml
+++ b/ansible/roles/monitor_remove/tasks/prometheus.yml
@@ -1,17 +1,17 @@
 ---
 - name: "1. Prometheus 서비스 중지"
-  ansible.builtin.systemd:
+  systemd:
     name: prometheus
     state: stopped
     enabled: no
   failed_when: false
 
 - name: "2. Prometheus 관련 경로 삭제"
-  ansible.builtin.file:
+  file:
     path: "{{ item }}"
     state: absent
   loop: "{{ prometheus_paths }}"
 
 - name: "3. systemd 데몬 리로드"
-  ansible.builtin.systemd:
+  systemd:
     daemon_reload: yes

--- a/ansible/roles/monitor_remove/tasks/prometheus.yml
+++ b/ansible/roles/monitor_remove/tasks/prometheus.yml
@@ -1,0 +1,17 @@
+---
+- name: "1. Prometheus 서비스 중지"
+  ansible.builtin.systemd:
+    name: prometheus
+    state: stopped
+    enabled: no
+  failed_when: false
+
+- name: "2. Prometheus 관련 경로 삭제"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: "{{ prometheus_paths }}"
+
+- name: "3. systemd 데몬 리로드"
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/ansible/roles/monitor_remove/vars/main.yml
+++ b/ansible/roles/monitor_remove/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# Role-level vars intentionally empty.

--- a/ansible/roles/monitor_setup/defaults/main.yml
+++ b/ansible/roles/monitor_setup/defaults/main.yml
@@ -1,0 +1,55 @@
+---
+# Monitoring Setup Role Defaults
+# 이 role 은 모니터링 서버(Local) 에 prometheus + grafana 를 설치합니다.
+# node_exporter 는 별도의 node_exporter_setup role 로 분리되어 있습니다.
+
+# 어떤 컴포넌트를 설치할지 — playbook 의 각 play 에서 오버라이드 가능
+monitoring_components:
+  - prometheus
+  - grafana
+
+# Node Exporter scrape port
+# (node_exporter_setup role 의 systemd unit 이 9100 으로 listen 하는 것과 일치해야 함)
+node_exporter_port: 9100
+
+# Prometheus (collection 활용)
+fixed_prometheus_version: "2.47.0"
+fixed_prometheus_targets:
+  on_premise:
+    - targets: "{{ groups['On-Premise'] | default([]) | map('regex_replace', '$', ':' ~ node_exporter_port | string) | list }}"
+      labels:
+        env: lab
+        tier: on-premise
+  ec2:
+    - targets: "{{ groups['EC2'] | default([]) | map('regex_replace', '$', ':' ~ node_exporter_port | string) | list }}"
+      labels:
+        env: lab
+        tier: ec2
+  db:
+    - targets: "{{ groups['DB'] | default([]) | map('regex_replace', '$', ':' ~ node_exporter_port | string) | list }}"
+      labels:
+        env: lab
+        tier: db
+  local:
+    - targets:
+        - "127.0.0.1:{{ node_exporter_port }}"
+      labels:
+        env: lab
+        tier: local
+fixed_prometheus_scrape_configs:
+  - job_name: on_premise
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/file_sd/on_premise.yml
+  - job_name: ec2
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/file_sd/ec2.yml
+  - job_name: db
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/file_sd/db.yml
+  - job_name: local
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/file_sd/local.yml

--- a/ansible/roles/monitor_setup/meta/main.yml
+++ b/ansible/roles/monitor_setup/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  author: AZAS Team
+  description: Install monitoring stack (node_exporter, prometheus, grafana)
+  company: AZAS
+  license: license (BSD, MIT)
+  min_ansible_version: 2.9
+
+dependencies: []
+
+# 외부 collection 의존성
+# (별도 requirements.yml 로 관리해도 무방하지만 참고용으로 명시)
+collections:
+  - prometheus.prometheus

--- a/ansible/roles/monitor_setup/tasks/grafana.yml
+++ b/ansible/roles/monitor_setup/tasks/grafana.yml
@@ -1,0 +1,46 @@
+---
+- name: "1. Grafana 의존성 패키지 설치"
+  package:
+    name: "{{ grafana_pkgs_required }}"
+    state: present
+
+# --- RedHat 계열 ---
+- name: "2. Grafana YUM 저장소 등록 (RedHat)"
+  copy:
+    dest: "{{ grafana_repo_path }}"
+    content: "{{ grafana_repo_content }}"
+  when: ansible_os_family == "RedHat"
+
+- name: "3. Grafana 설치 (RedHat)"
+  dnf:
+    name: grafana
+    state: present
+  when: ansible_os_family == "RedHat"
+
+# --- Debian 계열 ---
+- name: "4. Grafana GPG 키 등록 (Debian)"
+  apt_key:
+    url: "{{ grafana_apt_key_url }}"
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: "5. Grafana APT 저장소 등록 (Debian)"
+  apt_repository:
+    repo: "{{ grafana_apt_repo }}"
+    state: present
+    filename: "{{ grafana_apt_repo_filename }}"
+  when: ansible_os_family == "Debian"
+
+- name: "6. Grafana 설치 (Debian)"
+  apt:
+    name: grafana
+    state: present
+    update_cache: yes
+  when: ansible_os_family == "Debian"
+
+# --- 공통 ---
+- name: "7. Grafana 서비스 시작 및 자동실행"
+  systemd:
+    name: grafana-server
+    state: started
+    enabled: yes

--- a/ansible/roles/monitor_setup/tasks/main.yml
+++ b/ansible/roles/monitor_setup/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+# Monitoring Setup Role - Main task file
+# 컴포넌트는 monitoring_components 변수로 제어합니다.
+
+- name: "Monitoring stack setup"
+  block:
+    - name: "OS family fact 수집"
+      setup:
+        gather_subset: min
+      when: ansible_facts.os_family is not defined
+
+    - name: "OS-specific 변수 로드"
+      include_vars: "{{ ansible_os_family }}.yml"
+
+    - name: "Prometheus 설치"
+      include_tasks: prometheus.yml
+      when: "'prometheus' in monitoring_components"
+
+    - name: "Grafana 설치"
+      include_tasks: grafana.yml
+      when: "'grafana' in monitoring_components"

--- a/ansible/roles/monitor_setup/tasks/prometheus.yml
+++ b/ansible/roles/monitor_setup/tasks/prometheus.yml
@@ -1,0 +1,12 @@
+---
+# prometheus.prometheus.prometheus 컬렉션을 활용해 OS 비종속적으로 설치합니다.
+# 컬렉션이 없으면 사전에 다음 명령으로 설치하세요:
+#   ansible-galaxy collection install prometheus.prometheus
+
+- name: "1. Prometheus 설치 및 설정 (collection 활용)"
+  include_role:
+    name: prometheus.prometheus.prometheus
+  vars:
+    prometheus_version: "{{ fixed_prometheus_version }}"
+    prometheus_targets: "{{ fixed_prometheus_targets }}"
+    prometheus_scrape_configs: "{{ fixed_prometheus_scrape_configs }}"

--- a/ansible/roles/monitor_setup/vars/Debian.yml
+++ b/ansible/roles/monitor_setup/vars/Debian.yml
@@ -1,0 +1,11 @@
+---
+# Debian (Ubuntu/Debian) family vars
+
+grafana_pkgs_required:
+  - apt-transport-https
+  - wget
+  - gnupg2
+
+grafana_apt_key_url: https://packages.grafana.com/gpg.key
+grafana_apt_repo: "deb https://packages.grafana.com/oss/deb stable main"
+grafana_apt_repo_filename: grafana

--- a/ansible/roles/monitor_setup/vars/RedHat.yml
+++ b/ansible/roles/monitor_setup/vars/RedHat.yml
@@ -1,0 +1,18 @@
+---
+# RedHat (Rocky/RHEL/Amazon Linux) family vars
+
+grafana_pkgs_required:
+  - wget
+  - gnupg2
+
+grafana_repo_path: /etc/yum.repos.d/grafana.repo
+grafana_repo_content: |
+  [grafana]
+  name=grafana
+  baseurl=https://rpm.grafana.com
+  repo_gpgcheck=1
+  enabled=1
+  gpgcheck=1
+  gpgkey=https://rpm.grafana.com/gpg.key
+  sslverify=1
+  sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/ansible/roles/monitor_setup/vars/main.yml
+++ b/ansible/roles/monitor_setup/vars/main.yml
@@ -1,0 +1,4 @@
+---
+# Role-level vars intentionally empty.
+# OS-specific values live in vars/{{ ansible_os_family }}.yml and are loaded
+# at runtime by tasks/main.yml.

--- a/ansible/roles/node_exporter_remove/defaults/main.yml
+++ b/ansible/roles/node_exporter_remove/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Node Exporter Remove Role Defaults
+
+node_exporter_version: "1.7.0"
+node_exporter_user: node_exporter
+node_exporter_group: node_exporter
+node_exporter_archive_name: "node_exporter-{{ node_exporter_version }}.linux-amd64"
+node_exporter_archive_path: "/tmp/node_exporter-{{ node_exporter_version }}.tar.gz"
+node_exporter_binary_path: /usr/local/bin/node_exporter

--- a/ansible/roles/node_exporter_remove/meta/main.yml
+++ b/ansible/roles/node_exporter_remove/meta/main.yml
@@ -1,0 +1,9 @@
+---
+galaxy_info:
+  author: AZAS Team
+  description: Remove Prometheus Node Exporter
+  company: AZAS
+  license: license (BSD, MIT)
+  min_ansible_version: 2.9
+
+dependencies: []

--- a/ansible/roles/node_exporter_remove/tasks/main.yml
+++ b/ansible/roles/node_exporter_remove/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+# Node Exporter Remove Role - Main task file
+
+- name: "Node Exporter removal"
+  block:
+    - name: "Node Exporter 제거"
+      include_tasks: remove.yml

--- a/ansible/roles/node_exporter_remove/tasks/remove.yml
+++ b/ansible/roles/node_exporter_remove/tasks/remove.yml
@@ -1,43 +1,43 @@
 ---
 - name: "1. Node Exporter 서비스 중지"
-  ansible.builtin.systemd:
+  systemd:
     name: node_exporter
     state: stopped
     enabled: no
   failed_when: false
 
 - name: "2. Node Exporter systemd unit 삭제"
-  ansible.builtin.file:
+  file:
     path: /etc/systemd/system/node_exporter.service
     state: absent
 
 - name: "3. Node Exporter 실행 파일 삭제"
-  ansible.builtin.file:
+  file:
     path: "{{ node_exporter_binary_path }}"
     state: absent
 
 - name: "4. Node Exporter 압축 해제 디렉토리 삭제"
-  ansible.builtin.file:
+  file:
     path: "/tmp/{{ node_exporter_archive_name }}"
     state: absent
 
 - name: "5. Node Exporter 압축파일 삭제"
-  ansible.builtin.file:
+  file:
     path: "{{ node_exporter_archive_path }}"
     state: absent
 
 - name: "6. Node Exporter 시스템 사용자 제거"
-  ansible.builtin.user:
+  user:
     name: "{{ node_exporter_user }}"
     state: absent
   failed_when: false
 
 - name: "7. Node Exporter 그룹 제거"
-  ansible.builtin.group:
+  group:
     name: "{{ node_exporter_group }}"
     state: absent
   failed_when: false
 
 - name: "8. systemd 데몬 리로드"
-  ansible.builtin.systemd:
+  systemd:
     daemon_reload: yes

--- a/ansible/roles/node_exporter_remove/tasks/remove.yml
+++ b/ansible/roles/node_exporter_remove/tasks/remove.yml
@@ -1,0 +1,43 @@
+---
+- name: "1. Node Exporter 서비스 중지"
+  ansible.builtin.systemd:
+    name: node_exporter
+    state: stopped
+    enabled: no
+  failed_when: false
+
+- name: "2. Node Exporter systemd unit 삭제"
+  ansible.builtin.file:
+    path: /etc/systemd/system/node_exporter.service
+    state: absent
+
+- name: "3. Node Exporter 실행 파일 삭제"
+  ansible.builtin.file:
+    path: "{{ node_exporter_binary_path }}"
+    state: absent
+
+- name: "4. Node Exporter 압축 해제 디렉토리 삭제"
+  ansible.builtin.file:
+    path: "/tmp/{{ node_exporter_archive_name }}"
+    state: absent
+
+- name: "5. Node Exporter 압축파일 삭제"
+  ansible.builtin.file:
+    path: "{{ node_exporter_archive_path }}"
+    state: absent
+
+- name: "6. Node Exporter 시스템 사용자 제거"
+  ansible.builtin.user:
+    name: "{{ node_exporter_user }}"
+    state: absent
+  failed_when: false
+
+- name: "7. Node Exporter 그룹 제거"
+  ansible.builtin.group:
+    name: "{{ node_exporter_group }}"
+    state: absent
+  failed_when: false
+
+- name: "8. systemd 데몬 리로드"
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/ansible/roles/node_exporter_remove/vars/main.yml
+++ b/ansible/roles/node_exporter_remove/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# Role-level vars intentionally empty.

--- a/ansible/roles/node_exporter_setup/defaults/main.yml
+++ b/ansible/roles/node_exporter_setup/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Node Exporter Setup Role Defaults
+
+node_exporter_version: "1.7.0"
+node_exporter_user: node_exporter
+node_exporter_group: node_exporter
+node_exporter_archive_name: "node_exporter-{{ node_exporter_version }}.linux-amd64"
+node_exporter_archive_path: "/tmp/node_exporter-{{ node_exporter_version }}.tar.gz"
+node_exporter_binary_path: /usr/local/bin/node_exporter

--- a/ansible/roles/node_exporter_setup/meta/main.yml
+++ b/ansible/roles/node_exporter_setup/meta/main.yml
@@ -1,0 +1,9 @@
+---
+galaxy_info:
+  author: AZAS Team
+  description: Install Prometheus Node Exporter via prebuilt binary
+  company: AZAS
+  license: license (BSD, MIT)
+  min_ansible_version: 2.9
+
+dependencies: []

--- a/ansible/roles/node_exporter_setup/tasks/install.yml
+++ b/ansible/roles/node_exporter_setup/tasks/install.yml
@@ -1,0 +1,65 @@
+---
+- name: "1. 필수 라이브러리 설치"
+  package:
+    name: "{{ node_exporter_pkgs_required }}"
+    state: present
+
+- name: "2. Node Exporter 전용 그룹 생성"
+  group:
+    name: "{{ node_exporter_group }}"
+    system: yes
+    state: present
+
+- name: "3. Node Exporter 전용 시스템 사용자 생성"
+  user:
+    name: "{{ node_exporter_user }}"
+    group: "{{ node_exporter_group }}"
+    system: yes
+    shell: /usr/sbin/nologin
+    create_home: no
+    state: present
+
+- name: "4. Node Exporter 패키지 다운로드"
+  get_url:
+    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/{{ node_exporter_archive_name }}.tar.gz"
+    dest: "{{ node_exporter_archive_path }}"
+
+- name: "5. 압축 풀기"
+  unarchive:
+    src: "{{ node_exporter_archive_path }}"
+    dest: /tmp
+    remote_src: yes
+    creates: "/tmp/{{ node_exporter_archive_name }}/node_exporter"
+
+- name: "6. 실행 파일 이동 및 권한 설정"
+  copy:
+    src: "/tmp/{{ node_exporter_archive_name }}/node_exporter"
+    dest: "{{ node_exporter_binary_path }}"
+    mode: "0755"
+    owner: "{{ node_exporter_user }}"
+    group: "{{ node_exporter_group }}"
+    remote_src: yes
+
+- name: "7. Node Exporter systemd unit 등록"
+  copy:
+    dest: /etc/systemd/system/node_exporter.service
+    content: |
+      [Unit]
+      Description=Node Exporter
+      After=network.target
+
+      [Service]
+      User={{ node_exporter_user }}
+      Group={{ node_exporter_group }}
+      ExecStart={{ node_exporter_binary_path }}
+      Restart=always
+
+      [Install]
+      WantedBy=multi-user.target
+
+- name: "8. 서비스 시작 및 활성화"
+  systemd:
+    name: node_exporter
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/ansible/roles/node_exporter_setup/tasks/main.yml
+++ b/ansible/roles/node_exporter_setup/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# Node Exporter Setup Role - Main task file
+
+- name: "Node Exporter setup"
+  block:
+    - name: "OS family fact 수집"
+      setup:
+        gather_subset: min
+      when: ansible_facts.os_family is not defined
+
+    - name: "OS-specific 변수 로드"
+      include_vars: "{{ ansible_os_family }}.yml"
+
+    - name: "Node Exporter 설치"
+      include_tasks: install.yml

--- a/ansible/roles/node_exporter_setup/vars/Debian.yml
+++ b/ansible/roles/node_exporter_setup/vars/Debian.yml
@@ -1,0 +1,5 @@
+---
+node_exporter_pkgs_required:
+  - unzip
+  - tar
+  - python3-apt

--- a/ansible/roles/node_exporter_setup/vars/RedHat.yml
+++ b/ansible/roles/node_exporter_setup/vars/RedHat.yml
@@ -1,0 +1,4 @@
+---
+node_exporter_pkgs_required:
+  - tar
+  - gzip

--- a/ansible/roles/node_exporter_setup/vars/main.yml
+++ b/ansible/roles/node_exporter_setup/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# Role-level vars intentionally empty.
+# OS-specific values live in vars/{{ ansible_os_family }}.yml.


### PR DESCRIPTION
## Summary

- 배경: 재해 복구 시스템을 위한 모니터링 도구 필요
- 목적: 실시간 모니터링 툴을 통해 AWS 오토 스케일링을 트리거

## Changes

- Node Exporter 설치 및 제거 추가
- Prometheus & Grafana 설치 및 제거 추가

- 제거는 없어도 되나, 온프레미스 환경에서의 테스트 환경 일원화를 위해 추가함

## Review Points

- 중점적으로 봐야 할 부분:
  - 멱등성 준수 여부
  - 설치 이후, 정상 동작 여부