### PR TITLE
[FEAT#48] PostgreSQL 백업 및 복구 자동화 추가

### DIFF
--- a/ansible/postgresql_backup.yml
+++ b/ansible/postgresql_backup.yml
@@ -1,7 +1,7 @@
 # ~/ansible/postgresql_backup.yml
 ---
 - name: PostgreSQL 백업 실행
-  hosts: db_server
+  hosts: DB
   become: yes
   gather_facts: yes
   

--- a/ansible/postgresql_backup.yml
+++ b/ansible/postgresql_backup.yml
@@ -1,0 +1,9 @@
+# ~/ansible/postgresql_backup.yml
+---
+- name: PostgreSQL 백업 실행
+  hosts: db_server
+  become: yes
+  gather_facts: yes
+  
+  roles:
+    - postgresql_backup

--- a/ansible/postgresql_restore.yml
+++ b/ansible/postgresql_restore.yml
@@ -1,7 +1,7 @@
 # ~/ansible/postgresql_restore.yml
 ---
 - name: PostgreSQL 복구 실행
-  hosts: db_server
+  hosts: DB
   become: yes
   gather_facts: yes
 

--- a/ansible/postgresql_restore.yml
+++ b/ansible/postgresql_restore.yml
@@ -1,0 +1,9 @@
+# ~/ansible/postgresql_restore.yml
+---
+- name: PostgreSQL 복구 실행
+  hosts: db_server
+  become: yes
+  gather_facts: yes
+
+  roles:
+    - postgresql_restore

--- a/ansible/roles/postgresql_backup/defaults/main.yml
+++ b/ansible/roles/postgresql_backup/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+backup_dir: /tmp
+backup_filename: "full_db_backup_{{ ansible_date_time.date }}.sql"
+backup_path: "{{ backup_dir }}/{{ backup_filename }}"
+backup_user: postgres
+keep_days: 7
+
+mgmt_backup_dir: /tmp

--- a/ansible/roles/postgresql_backup/tasks/backup.yml
+++ b/ansible/roles/postgresql_backup/tasks/backup.yml
@@ -3,7 +3,7 @@
   ansible.builtin.file:
     path: "{{ backup_dir }}"
     state: directory
-    mode: '0700'
+    mode: '1777'
 
 - name: PostgreSQL 서비스 활성 상태 확인
   ansible.builtin.command: systemctl is-active postgresql

--- a/ansible/roles/postgresql_backup/tasks/backup.yml
+++ b/ansible/roles/postgresql_backup/tasks/backup.yml
@@ -1,0 +1,73 @@
+---
+- name: 백업 디렉토리 존재 확인 및 생성
+  ansible.builtin.file:
+    path: "{{ backup_dir }}"
+    state: directory
+    mode: '1777'
+
+- name: PostgreSQL 서비스 활성 상태 확인
+  ansible.builtin.command: systemctl is-active postgresql
+  register: pg_status
+  changed_when: false
+  failed_when: pg_status.stdout != "active"
+
+- name: pg_dumpall 실행 - 전체 DB 백업
+  ansible.builtin.command:
+    cmd: "pg_dumpall -f {{ backup_path }}"
+  become: yes
+  become_user: "{{ backup_user }}"
+  register: backup_result
+  changed_when: true
+
+- name: 백업 파일 존재 및 크기 확인
+  ansible.builtin.stat:
+    path: "{{ backup_path }}"
+  register: backup_stat
+
+- name: 백업 결과 출력
+  ansible.builtin.debug:
+    msg:
+      - "백업 파일 경로 : {{ backup_path }}"
+      - "파일 크기      : {{ (backup_stat.stat.size / 1024 / 1024) | round(2) }} MB"
+      - "생성 시각      : {{ ansible_date_time.iso8601 }}"
+
+- name: 백업 파일 미생성 시 실패 처리
+  ansible.builtin.fail:
+    msg: "백업 파일이 생성되지 않았거나 크기가 0입니다."
+  when: not backup_stat.stat.exists or backup_stat.stat.size == 0
+
+- name: 오래된 백업 파일 삭제 ({{ keep_days }}일 초과)
+  ansible.builtin.find:
+    paths: "{{ backup_dir }}"
+    patterns: "full_db_backup_*.sql"
+    age: "{{ keep_days }}d"
+    recurse: no
+  register: old_backups
+
+- name: 오래된 파일 제거
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ old_backups.files }}"
+  when: old_backups.files | length > 0
+
+- name: 삭제된 오래된 백업 목록 출력
+  ansible.builtin.debug:
+    msg: "삭제된 파일: {{ old_backups.files | map(attribute='path') | list }}"
+  when: old_backups.files | length > 0
+
+- name: mgmt 서버로 백업 파일 가져오기
+  ansible.builtin.fetch:
+    src: "{{ backup_path }}"
+    dest: "{{ mgmt_backup_dir }}/"
+    flat: yes
+
+- name: S3 변수 로드
+  ansible.builtin.include_vars:
+    file: "{{ role_path }}/vars/s3_vars.yml"
+
+- name: S3에 백업 파일 업로드
+  ansible.builtin.command:
+    cmd: "aws s3 cp {{ mgmt_backup_dir }}/{{ backup_filename }} s3://{{ s3_bucket_name }}/{{ backup_filename }}"
+  delegate_to: localhost
+  become: no

--- a/ansible/roles/postgresql_backup/tasks/backup.yml
+++ b/ansible/roles/postgresql_backup/tasks/backup.yml
@@ -3,7 +3,7 @@
   ansible.builtin.file:
     path: "{{ backup_dir }}"
     state: directory
-    mode: '1777'
+    mode: '0700'
 
 - name: PostgreSQL 서비스 활성 상태 확인
   ansible.builtin.command: systemctl is-active postgresql

--- a/ansible/roles/postgresql_backup/tasks/main.yml
+++ b/ansible/roles/postgresql_backup/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: DB 백업 실행
+  block:
+    - name: PostgreSQL 백업 실행  
+      include_tasks: backup.yml

--- a/ansible/roles/postgresql_restore/defaults/main.yml
+++ b/ansible/roles/postgresql_restore/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+backup_dir: /tmp
+backup_filename: "full_db_backup_{{ ansible_date_time.date }}.sql"
+backup_path: "{{ backup_dir }}/{{ backup_filename }}"
+backup_user: postgres
+keep_days: 7
+
+mgmt_backup_dir: /tmp

--- a/ansible/roles/postgresql_restore/tasks/main.yml
+++ b/ansible/roles/postgresql_restore/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: DB 복구 실행
+  block:
+    - name: PostgreSQL 복구 실행
+      include_tasks: restore.yml

--- a/ansible/roles/postgresql_restore/tasks/restore.yml
+++ b/ansible/roles/postgresql_restore/tasks/restore.yml
@@ -1,0 +1,27 @@
+---
+- name: "0. 최신 백업 파일 찾기"
+  ansible.builtin.shell:
+    cmd: "ls -t {{ mgmt_backup_dir }}/full_db_backup_*.sql | head -1"
+  register: latest_backup
+  delegate_to: localhost
+  become: no
+
+- name: "1. mgmt 백업 파일을 db EC2로 전송"
+  ansible.builtin.copy:
+    src: "{{ restore_filename | default(latest_backup.stdout | trim) }}"
+    dest: "/tmp/{{ restore_filename | default(latest_backup.stdout | trim | basename) }}"
+    owner: postgres
+    group: postgres
+    mode: '0644'
+
+- name: "2. 백업파일로 전체 데이터 복구"
+  ansible.builtin.shell:
+    cmd: "psql -f /tmp/{{ restore_filename | default(latest_backup.stdout | trim | basename) }} postgres"
+  become_user: postgres
+  ignore_errors: yes
+  register: restore_result
+
+- name: "3. 복구 결과 확인"
+  ansible.builtin.debug:
+    msg: "데이터 복구 작업이 완료되었습니다"
+  when: restore_result is succeeded

--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -6,6 +6,7 @@ resource "aws_instance" "app_server" {
   subnet_id              = aws_subnet.private_subnet_a.id
   vpc_security_group_ids = [aws_security_group.ec2_sg.id]
   key_name               = aws_key_pair.kp.key_name     #azas-key
+  iam_instance_profile   = aws_iam_instance_profile.ec2_profile.name
   tags                   = { Name = "azas-ec2" }
 }
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -5,6 +5,10 @@ terraform {
             source = "hashicorp/aws"
             version = "~> 6.0" 
       }
+      random = {
+            source  = "hashicorp/random"
+            version = "~> 3.0"
+      }
       # cloudflare = {
       #       source  = "cloudflare/cloudflare"
       #       version = "~> 4.0"

--- a/terraform/s3_bucket.tf
+++ b/terraform/s3_bucket.tf
@@ -1,0 +1,40 @@
+
+resource "random_id" "bucket_suffix" {
+    byte_length = 4
+}
+
+resource "aws_s3_bucket" "app_bucket" {
+    bucket = "azas-backup-bucket-${random_id.bucket_suffix.hex}"
+    tags   = { Name = "azas-s3" }
+}
+
+resource "aws_iam_role" "ec2_s3_role" {
+    name = "azas-ec2-s3-role"
+    assume_role_policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [{
+            Action    = "sts:AssumeRole"
+            Effect    = "Allow"
+            Principal = { Service = "ec2.amazonaws.com" }
+        }]
+    })
+    tags = { Name = "azas-ec2-s3-role" }
+}
+
+resource "aws_iam_role_policy_attachment" "s3_full_access" {
+    role       = aws_iam_role.ec2_s3_role.name
+    policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+resource "aws_iam_instance_profile" "ec2_profile" {
+    name = "azas-ec2-instance-profile"
+    role = aws_iam_role.ec2_s3_role.name
+}
+
+# 생성 버킷이름 local_file 로 넘김 (ansible에서 사용)
+resource "local_file" "ansible_s3_vars" {
+    filename = "${path.module}/../ansible/roles/pg_backup/vars/s3_vars.yml"
+    content  = yamlencode({
+        s3_bucket_name = aws_s3_bucket.app_bucket.id
+    })
+}

--- a/terraform/s3_bucket.tf
+++ b/terraform/s3_bucket.tf
@@ -33,7 +33,7 @@ resource "aws_iam_instance_profile" "ec2_profile" {
 
 # 생성 버킷이름 local_file 로 넘김 (ansible에서 사용)
 resource "local_file" "ansible_s3_vars" {
-    filename = "${path.module}/../ansible/roles/pg_backup/vars/s3_vars.yml"
+    filename = "${path.module}/../ansible/roles/postgresql_backup/vars/s3_vars.yml"
     content  = yamlencode({
         s3_bucket_name = aws_s3_bucket.app_bucket.id
     })


### PR DESCRIPTION
## Summary

- 배경: DB 백업/복구 자동화 필요
- 목적: Ansible role 기반 백업·복구 및 S3 연동

## Changes

- pg_backup role: DB 백업 생성 → mgmt fetch → s3 업로드
- pg_restore role: mgmt 백업 파일 → db EC2 복구
- s3_bucket.tf: s3 및 IAM role 생성, s3_vars.yml 자동 주입

## Review Points

- 중점적으로 봐야 할 부분: 중복 에러 없이 정상 동작 여부